### PR TITLE
Register namespaces to get rid of etree's "ns0" prefix

### DIFF
--- a/ogcserver/wms111.py
+++ b/ogcserver/wms111.py
@@ -3,6 +3,8 @@
 from mapnik import Coord
 
 from xml.etree import ElementTree
+ElementTree.register_namespace('', "http://www.opengis.net/wms")
+ElementTree.register_namespace('xlink', "http://www.w3.org/1999/xlink")
 
 from ogcserver.common import ParameterDefinition, Response, Version, ListFactory, \
                    ColorFactory, CRSFactory, WMSBaseServiceHandler, CRS, \
@@ -81,7 +83,7 @@ class ServiceHandler(WMSBaseServiceHandler):
             <DCPType>
               <HTTP>
                 <Get>
-                  <OnlineResource xlink:type="simple"/>
+                  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"/>
                 </Get>
               </HTTP>
             </DCPType>
@@ -91,7 +93,7 @@ class ServiceHandler(WMSBaseServiceHandler):
             <DCPType>
               <HTTP>
                 <Get>
-                  <OnlineResource xlink:type="simple"/>
+                  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"/>
                 </Get>
               </HTTP>
             </DCPType>
@@ -125,7 +127,7 @@ class ServiceHandler(WMSBaseServiceHandler):
 
             elements = capetree.findall('Capability//OnlineResource')
             for element in elements:
-                element.set('{http://www.w3.org/1999/xlink}href', self.opsonlineresource)
+                element.set('xlink:href', self.opsonlineresource)
 
             self.processServiceCapabilities(capetree)
 

--- a/ogcserver/wms130.py
+++ b/ogcserver/wms130.py
@@ -3,6 +3,8 @@
 from mapnik import Coord
 
 from xml.etree import ElementTree
+ElementTree.register_namespace('', "http://www.opengis.net/wms")
+ElementTree.register_namespace('xlink', "http://www.w3.org/1999/xlink")
 
 from ogcserver.common import ParameterDefinition, Response, Version, ListFactory, \
                    ColorFactory, CRSFactory, CRS, WMSBaseServiceHandler, \
@@ -132,7 +134,7 @@ class ServiceHandler(WMSBaseServiceHandler):
 
             elements = capetree.findall('{http://www.opengis.net/wms}Capability//{http://www.opengis.net/wms}OnlineResource')
             for element in elements:
-                element.set('{http://www.w3.org/1999/xlink}href', self.opsonlineresource)
+                element.set('xlink:href', self.opsonlineresource)
 
             self.processServiceCapabilities(capetree)
 


### PR DESCRIPTION
In current master, etree adds "ns0:" prefix to xlink attributes in GetCapabilities document. This has no effect for direct GetMap requests, but can cause Capabilities-dependent applications such as QGIS to break. I have registered the default namespace and xlink namespace according to http://stackoverflow.com/questions/8983041/saving-xml-files-using-elementtree, and managed QGIS to work with OGCServer service. 
