### PR TITLE
Added support for load_map_from_string in BaseWMSFactory.loadXML method (2)

### DIFF
--- a/ogcserver/WMS.py
+++ b/ogcserver/WMS.py
@@ -64,8 +64,11 @@ class BaseWMSFactory:
         tmp_map = Map(0,0)
         if xmlfile:
             load_map(tmp_map, xmlfile, strict)
-        else:
+        elif xmlstring:
             load_map_from_string(tmp_map, xmlstring, strict, basepath)
+        else:
+            raise ServerConfigurationError("Mapnik configuration XML is not specified - 'xmlfile' and 'xmlstring' variables are empty.\
+Please set one of this variables to load mapnik map object.")
         # parse map level attributes
         if tmp_map.background:
             self.map_attributes['bgcolor'] = tmp_map.background

--- a/tests/testLoadMapFail.py
+++ b/tests/testLoadMapFail.py
@@ -1,0 +1,10 @@
+import nose
+import os
+from ogcserver.WMS import BaseWMSFactory
+from ogcserver.exceptions import ServerConfigurationError
+
+def test_wms_capabilities():
+    wms = BaseWMSFactory()
+    nose.tools.assert_raises(ServerConfigurationError, wms.loadXML)
+    
+    return True

--- a/tests/testLoadMapFromString.py
+++ b/tests/testLoadMapFromString.py
@@ -1,9 +1,6 @@
 import nose
 import os
-from ogcserver.configparser import SafeConfigParser
 from ogcserver.WMS import BaseWMSFactory
-from ogcserver.wms111 import ServiceHandler as ServiceHandler111
-from ogcserver.wms130 import ServiceHandler as ServiceHandler130
 
 def test_wms_capabilities():
     base_path, tail = os.path.split(__file__)


### PR DESCRIPTION
Hi,
This pull request adds possibility to load mapnik XML configuration from string using load_map_from_string function. There is a check if 'xmlfile' is existing file (os.path.isfile) - if not 'load_map_from_string' will be used.
This is second pull request after #26 - earlier I've add wrong checkig - sorry for that.

Regards
Piotr Pociask
