### PR TITLE
Scale support

### DIFF
--- a/ogcserver/WMS.py
+++ b/ogcserver/WMS.py
@@ -4,6 +4,7 @@ import re
 import sys
 import ConfigParser
 from mapnik import Style, Map, load_map, load_map_from_string, Envelope, Coord
+import logging
 
 from ogcserver import common
 from ogcserver.wms111 import ServiceHandler as ServiceHandler111

--- a/ogcserver/WMS.py
+++ b/ogcserver/WMS.py
@@ -52,7 +52,6 @@ class BaseWMSFactory:
         self.meta_layers = {}
         self.configpath = configpath
         self.latlonbb = None
-        log = logging.getLogger('ogcserver.wsgi')
 
     def loadXML(self, xmlfile=None, strict=False, xmlstring='', basepath=''):
         config = ConfigParser.SafeConfigParser()

--- a/ogcserver/WMS.py
+++ b/ogcserver/WMS.py
@@ -4,7 +4,6 @@ import re
 import sys
 import ConfigParser
 from mapnik import Style, Map, load_map, load_map_from_string, Envelope, Coord
-import logging
 
 from ogcserver import common
 from ogcserver.wms111 import ServiceHandler as ServiceHandler111

--- a/ogcserver/WMS.py
+++ b/ogcserver/WMS.py
@@ -47,10 +47,12 @@ class BaseWMSFactory:
         self.styles = {}
         self.aggregatestyles = {}
         self.map_attributes = {}
+        self.map_scale = 1
         self.meta_styles = {}
         self.meta_layers = {}
         self.configpath = configpath
         self.latlonbb = None
+        log = logging.getLogger('ogcserver.wsgi')
 
     def loadXML(self, xmlfile=None, strict=False, xmlstring='', basepath=''):
         config = ConfigParser.SafeConfigParser()
@@ -69,6 +71,10 @@ class BaseWMSFactory:
         else:
             raise ServerConfigurationError("Mapnik configuration XML is not specified - 'xmlfile' and 'xmlstring' variables are empty.\
 Please set one of this variables to load mapnik map object.")
+        # get the map scale
+        if tmp_map.parameters:
+            if tmp_map.parameters['scale']:
+                self.map_scale = float(tmp_map.parameters['scale'])
         # parse map level attributes
         if tmp_map.background:
             self.map_attributes['bgcolor'] = tmp_map.background

--- a/ogcserver/common.py
+++ b/ogcserver/common.py
@@ -318,7 +318,8 @@ class WMSBaseServiceHandler(BaseServiceHandler):
     def GetMap(self, params):
         m = self._buildMap(params)
         im = Image(params['width'], params['height'])
-        render(m, im, self.mapfactory.map_scale)
+        map_scale = self.mapfactory.map_scale if self.mapfactory is not None else 1
+        render(m, im, map_scale)
         format = PIL_TYPE_MAPPING[params['format']]
         if mapnik_version() >= 200300:
             # Mapnik 2.3 uses png8 as default, use png32 for backwards compatibility

--- a/ogcserver/common.py
+++ b/ogcserver/common.py
@@ -295,8 +295,10 @@ def copy_layer(obj):
     if hasattr(obj, 'toleranceunits'):
         lyr.toleranceunits = obj.toleranceunits
     lyr.srs = obj.srs
-    lyr.minzoom = obj.minzoom
-    lyr.maxzoom = obj.maxzoom
+    if hasattr(obj, 'minzoom'):
+        lyr.minzoom = obj.minzoom
+    if hasattr(obj, 'maxzoom'):
+      lyr.maxzoom = obj.maxzoom
     lyr.active = obj.active
     lyr.queryable = obj.queryable    
     lyr.clear_label_cache = obj.clear_label_cache
@@ -316,7 +318,7 @@ class WMSBaseServiceHandler(BaseServiceHandler):
     def GetMap(self, params):
         m = self._buildMap(params)
         im = Image(params['width'], params['height'])
-        render(m, im)
+        render(m, im, self.mapfactory.map_scale)
         format = PIL_TYPE_MAPPING[params['format']]
         if mapnik_version() >= 200300:
             # Mapnik 2.3 uses png8 as default, use png32 for backwards compatibility
@@ -537,7 +539,7 @@ class BaseExceptionHandler:
         e.text = message
         if code:
             e.set('code', code)
-        return Response(self.xmlmimetype, ElementTree.tostring(ogcexcetree), status_code=404)
+        return Response(self.xmlmimetype, ElementTree.tostring(ogcexcetree,pretty_print=True), status_code=404)
 
     def inimagehandler(self, code, message, params):
         im = new('RGBA', (int(params['width']), int(params['height'])))

--- a/ogcserver/common.py
+++ b/ogcserver/common.py
@@ -540,7 +540,7 @@ class BaseExceptionHandler:
         e.text = message
         if code:
             e.set('code', code)
-        return Response(self.xmlmimetype, ElementTree.tostring(ogcexcetree,pretty_print=True), status_code=404)
+        return Response(self.xmlmimetype, ElementTree.tostring(ogcexcetree, pretty_print=True), status_code=404)
 
     def inimagehandler(self, code, message, params):
         im = new('RGBA', (int(params['width']), int(params['height'])))


### PR DESCRIPTION
This is useful when rendering HiDpi or retina
maps, especially when ogcserver is used behind
a tile server.